### PR TITLE
Fix scale naming

### DIFF
--- a/src/FindScale.jsx
+++ b/src/FindScale.jsx
@@ -21,15 +21,15 @@ export const notesOtherNames = {
 
 const scales = [
   {
-    name: "Accord Major",
+    name: "Chord Major",
     scale: [4, 3]
   },
   {
-    name: "Accord Minor",
+    name: "Chord Minor",
     scale: [3, 4]
   },
   {
-    name: "Accord Dim",
+    name: "Chord Dim",
     scale: [3, 3, 3]
   },
   {


### PR DESCRIPTION
## Summary
- correct names of chord scales in `FindScale.jsx`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847c8cf62108324a1edccd88f411f43