### PR TITLE
Add React Router

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ The project provides two tools:
 - **FindScale** — helps you find the notes of common chords and scales and
   displays them on the fretboard.
 
+Each tool is available under its own URL:
+
+- `http://localhost:5173/train-notes` for **TrainNotes**
+- `http://localhost:5173/find-scale` for **FindScale**
+
 ## Running
 
 Install dependencies first:

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "@mui/material": "^7.1.1",
         "es-toolkit": "^1.39.3",
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "react-router-dom": "^6.30.1"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.27.2",
@@ -3245,6 +3246,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -6810,6 +6820,38 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-router": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
+      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
+      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0",
+        "react-router": "6.30.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
     },
     "node_modules/react-transition-group": {
       "version": "4.4.5",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "@mui/material": "^7.1.1",
     "es-toolkit": "^1.39.3",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-router-dom": "^6.30.1"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.27.2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,19 +1,38 @@
-import React, { useState } from 'react';
+import React from 'react';
 import type { JSX } from 'react';
 import { FindScaleApp } from './FindScale';
 import { TrainNotesApp } from './TrainNotes';
-import { CssBaseline, RadioGroup, FormControlLabel, Radio, Stack } from '@mui/material';
+import {
+  CssBaseline,
+  RadioGroup,
+  FormControlLabel,
+  Radio,
+  Stack
+} from '@mui/material';
+import {
+  Routes,
+  Route,
+  Navigate,
+  useNavigate,
+  useLocation
+} from 'react-router-dom';
 
 export default function App(): JSX.Element {
-  const [app, setApp] = useState("TrainNotesApp");
+  const navigate = useNavigate();
+  const location = useLocation();
+  const current = location.pathname.includes('find-scale') ? 'FindScaleApp' : 'TrainNotesApp';
+
   return (
     <React.Fragment>
       <CssBaseline />
       <Stack sx={{ p: 2 }}>
         <RadioGroup
           row
-          value={app}
-          onChange={(e) => setApp((e.target as HTMLInputElement).value)}
+          value={current}
+          onChange={(e) => {
+            const value = (e.target as HTMLInputElement).value;
+            navigate(value === 'TrainNotesApp' ? '/train-notes' : '/find-scale');
+          }}
         >
           <FormControlLabel
             value="TrainNotesApp"
@@ -27,8 +46,11 @@ export default function App(): JSX.Element {
           />
         </RadioGroup>
       </Stack>
-      {app === 'TrainNotesApp' && <TrainNotesApp/>}
-      {app === 'FindScaleApp' && <FindScaleApp/>}
+      <Routes>
+        <Route path="/train-notes" element={<TrainNotesApp />} />
+        <Route path="/find-scale" element={<FindScaleApp />} />
+        <Route path="*" element={<Navigate to="/train-notes" replace />} />
+      </Routes>
     </React.Fragment>
   );
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
-import App from './App'
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
 const container = document.getElementById('root') as HTMLElement;
 const root = createRoot(container);
 root.render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- install `react-router-dom`
- wire BrowserRouter into the entry point
- add routes for TrainNotes and FindScale apps
- keep navigation via radio buttons
- document app URLs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68480a7a84708324a69ea2d2e174936b